### PR TITLE
fix(evaluation): support bilingual DE-Arch scores

### DIFF
--- a/dacomp-de/evaluation_suite_arch/evaluate.py
+++ b/dacomp-de/evaluation_suite_arch/evaluate.py
@@ -15,6 +15,7 @@ import re
 
 import openai
 from utils.eval_prompt import eval_prompt, eval_prompt_zh
+from utils.scoring import extract_actual_score
 from utils.config import (
     SUPPORTED_MODELS,
     DEFAULT_RESULTS_DIR,
@@ -278,16 +279,8 @@ class DEDEvaluator:
             return {"parse_error": str(e), "raw_content": response_content}
 
     def extract_actual_score(self, evaluation_result: Dict[str, Any]) -> int:
-        """Extract actual score from evaluation result (retains CN keys)."""
-        if "总得分" in evaluation_result:
-            return evaluation_result["总得分"]
-        elif "parse_error" not in evaluation_result:
-            total_score = 0
-            for value in evaluation_result.values():
-                if isinstance(value, dict) and "总得分" in value:
-                    total_score += value["总得分"]
-            return total_score
-        return 0
+        """Extract actual score from a bilingual judge response."""
+        return extract_actual_score(evaluation_result)
 
     def save_task_result(self, result: Dict[str, Any]) -> str:
         """Save evaluation result for a single task."""

--- a/dacomp-de/evaluation_suite_arch/evaluate.py
+++ b/dacomp-de/evaluation_suite_arch/evaluate.py
@@ -91,14 +91,42 @@ class DEDEvaluator:
         return data
 
     def _select_gold(self, task_name: str, project_path: str):
-        is_zh = task_name.endswith("-zh") or "arch-zh" in str(project_path)
-        gold_map = self.gold_zh_map if is_zh else self.gold_en_map
-        if task_name not in gold_map and not is_zh and f"{task_name}-zh" in self.gold_zh_map:
-            gold_map = self.gold_zh_map
-            is_zh = True
-        if task_name not in gold_map:
-            raise FileNotFoundError(f"Gold question/rubric not found for task {task_name}")
-        return gold_map, is_zh
+        zh_task_name = task_name if task_name.endswith("-zh") else f"{task_name}-zh"
+        project_is_zh = "arch-zh" in str(project_path).lower()
+
+        if task_name.endswith("-zh"):
+            candidates = ((self.gold_zh_map, task_name, True),)
+        elif project_is_zh:
+            candidates = (
+                (self.gold_zh_map, zh_task_name, True),
+                (self.gold_en_map, task_name, False),
+            )
+        else:
+            candidates = (
+                (self.gold_en_map, task_name, False),
+                (self.gold_zh_map, zh_task_name, True),
+            )
+
+        fallback = None
+        for gold_map, gold_task_name, is_zh in candidates:
+            gold = gold_map.get(gold_task_name)
+            if gold is None:
+                continue
+            if fallback is None:
+                fallback = (gold, is_zh)
+            if self._rubric_is_complete(gold["rubric"]):
+                return gold, is_zh
+
+        if fallback is not None:
+            return fallback
+        raise FileNotFoundError(f"Gold question/rubric not found for task {task_name}")
+
+    def _rubric_is_complete(self, rubric_content: str) -> bool:
+        """Return whether a rubric has a denominator and a complete final line."""
+        rubric = rubric_content.rstrip()
+        if not rubric or self.extract_max_score_from_rubric(rubric) <= 0:
+            return False
+        return rubric.endswith((".", "!", "?", "。", "！", "？", ")", "]", "`"))
 
     def _list_tasks_in_dir(self, project_dir: Path) -> List[str]:
         tasks: List[str] = []
@@ -210,28 +238,31 @@ class DEDEvaluator:
         with self.lock:
             logger.info(f"Start evaluating task: {project_path}/{task_name}")
 
-        gold_map, is_zh = self._select_gold(task_name, project_path)
-
-        blueprint_content = self.load_blueprint_from_results(project_path, task_name)
-        question_content = gold_map[task_name]["question"]
-        rubric_content = gold_map[task_name]["rubric"]
-
-        max_score = self.extract_max_score_from_rubric(rubric_content)
-
-        prompt_tpl = eval_prompt_zh if is_zh else eval_prompt
-        formatted_prompt = prompt_tpl.format(
-            user_query=question_content,
-            model_blueprint=blueprint_content,
-            rubric=rubric_content
-        )
-
-        with self.lock:
-            logger.info(f"Calling LLM: {project_path}/{task_name}...")
-
+        max_score = 0
         try:
+            gold, is_zh = self._select_gold(task_name, project_path)
+            rubric_content = gold["rubric"]
+            max_score = self.extract_max_score_from_rubric(rubric_content)
+            if not self._rubric_is_complete(rubric_content):
+                raise ValueError(f"Gold rubric is missing or truncated for task {task_name}")
+
+            blueprint_content = self.load_blueprint_from_results(project_path, task_name)
+            if not blueprint_content.strip():
+                raise ValueError(f"Blueprint is empty for task {task_name}")
+
+            prompt_tpl = eval_prompt_zh if is_zh else eval_prompt
+            formatted_prompt = prompt_tpl.format(
+                user_query=gold["question"],
+                model_blueprint=blueprint_content,
+                rubric=rubric_content
+            )
+
+            with self.lock:
+                logger.info(f"Calling LLM: {project_path}/{task_name}...")
+
             response_content = self.call_llm_api(formatted_prompt, self.eval_model)
 
-            if response_content is None:
+            if not response_content or not response_content.strip():
                 raise Exception("LLM call failed")
 
             evaluation_result = self.parse_evaluation_result(response_content)

--- a/dacomp-de/evaluation_suite_arch/utils/config.py
+++ b/dacomp-de/evaluation_suite_arch/utils/config.py
@@ -2,10 +2,10 @@
 from pathlib import Path
 
 # Base paths
-BASE_DIR = Path(__file__).resolve().parent
-DEFAULT_RESULTS_DIR = BASE_DIR / "results"
-DEFAULT_GOLD_EN_JSONL = BASE_DIR / "gold" / "dacomp-arch-gold.jsonl"
-DEFAULT_GOLD_ZH_JSONL = BASE_DIR / "gold" / "dacomp-arch-zh-gold.jsonl"
+SUITE_DIR = Path(__file__).resolve().parent.parent
+DEFAULT_RESULTS_DIR = SUITE_DIR / "results"
+DEFAULT_GOLD_EN_JSONL = SUITE_DIR / "gold" / "dacomp-arch-gold.jsonl"
+DEFAULT_GOLD_ZH_JSONL = SUITE_DIR / "gold" / "dacomp-arch-zh-gold.jsonl"
 
 # API defaults
 DEFAULT_BASE_URL = ""

--- a/dacomp-de/evaluation_suite_arch/utils/scoring.py
+++ b/dacomp-de/evaluation_suite_arch/utils/scoring.py
@@ -1,0 +1,23 @@
+from typing import Any
+
+TOTAL_SCORE_KEYS = ("总得分", "Total Score", "total_score")
+
+
+def extract_actual_score(evaluation_result: dict[str, Any]) -> int:
+    """Extract a bilingual total score from a DE-Arch judge response."""
+    for key in TOTAL_SCORE_KEYS:
+        if key in evaluation_result:
+            return evaluation_result[key]
+
+    if "parse_error" in evaluation_result:
+        return 0
+
+    total_score = 0
+    for value in evaluation_result.values():
+        if not isinstance(value, dict):
+            continue
+        for key in TOTAL_SCORE_KEYS:
+            if key in value:
+                total_score += value[key]
+                break
+    return total_score

--- a/tests/test_de_arch_evaluation.py
+++ b/tests/test_de_arch_evaluation.py
@@ -1,0 +1,51 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SUITE_DIR = ROOT / "dacomp-de" / "evaluation_suite_arch"
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+scoring = load_module("de_arch_scoring", SUITE_DIR / "utils" / "scoring.py")
+config = load_module("de_arch_config", SUITE_DIR / "utils" / "config.py")
+
+
+@pytest.mark.parametrize(
+    ("result", "expected"),
+    [
+        ({"总得分": 12}, 12),
+        ({"Total Score": 11}, 11),
+        ({"total_score": 10}, 10),
+        (
+            {
+                "Requirement 1": {"Total Score": 4},
+                "Requirement 2": {"总得分": 5},
+                "Requirement 3": {"total_score": 3},
+            },
+            12,
+        ),
+        ({"parse_error": "invalid JSON", "raw_content": "{"}, 0),
+    ],
+)
+def test_extract_actual_score_supports_bilingual_responses(result, expected):
+    assert scoring.extract_actual_score(result) == expected
+
+
+def test_default_gold_paths_point_to_shipped_files():
+    assert config.DEFAULT_GOLD_EN_JSONL.is_file()
+    assert config.DEFAULT_GOLD_ZH_JSONL.is_file()
+    assert config.DEFAULT_GOLD_EN_JSONL.parent == SUITE_DIR / "gold"
+    assert config.DEFAULT_GOLD_ZH_JSONL.parent == SUITE_DIR / "gold"
+
+
+def test_default_results_path_is_relative_to_evaluation_suite():
+    assert config.DEFAULT_RESULTS_DIR == SUITE_DIR / "results"

--- a/tests/test_de_arch_evaluation.py
+++ b/tests/test_de_arch_evaluation.py
@@ -1,10 +1,13 @@
 import importlib.util
+import sys
+import threading
 from pathlib import Path
 
 import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 SUITE_DIR = ROOT / "dacomp-de" / "evaluation_suite_arch"
+sys.path.insert(0, str(SUITE_DIR))
 
 
 def load_module(name: str, path: Path):
@@ -17,6 +20,16 @@ def load_module(name: str, path: Path):
 
 scoring = load_module("de_arch_scoring", SUITE_DIR / "utils" / "scoring.py")
 config = load_module("de_arch_config", SUITE_DIR / "utils" / "config.py")
+evaluation = load_module("de_arch_evaluation", SUITE_DIR / "evaluate.py")
+
+
+def make_evaluator(en_map=None, zh_map=None):
+    evaluator = evaluation.DEDEvaluator.__new__(evaluation.DEDEvaluator)
+    evaluator.gold_en_map = en_map or {}
+    evaluator.gold_zh_map = zh_map or {}
+    evaluator.lock = threading.Lock()
+    evaluator.eval_model = "test-model"
+    return evaluator
 
 
 @pytest.mark.parametrize(
@@ -49,3 +62,91 @@ def test_default_gold_paths_point_to_shipped_files():
 
 def test_default_results_path_is_relative_to_evaluation_suite():
     assert config.DEFAULT_RESULTS_DIR == SUITE_DIR / "results"
+
+
+def test_language_selection_supports_suffixed_and_legacy_task_names():
+    en = {"question": "English question", "rubric": "## [Total Score | 1 Point]."}
+    zh = {"question": "中文问题", "rubric": "## [总分 | 1 分]。"}
+    evaluator = make_evaluator(
+        {"dacomp-de-arch-001": en},
+        {"dacomp-de-arch-001-zh": zh},
+    )
+
+    assert evaluator._select_gold("dacomp-de-arch-001", "/results/en") == (en, False)
+    assert evaluator._select_gold("dacomp-de-arch-001-zh", "/results/en") == (zh, True)
+    assert evaluator._select_gold("dacomp-de-arch-001", "/results/arch-zh") == (zh, True)
+
+
+def test_language_selection_falls_back_from_truncated_english_rubric():
+    truncated_en = {
+        "question": "English question",
+        "rubric": "## [Total Score | 1 Point]\nCriterion starts but is trunc",
+    }
+    zh = {"question": "中文问题", "rubric": "## [总分 | 1 分]\n标准完整。"}
+    evaluator = make_evaluator(
+        {"dacomp-de-arch-001": truncated_en},
+        {"dacomp-de-arch-001-zh": zh},
+    )
+
+    assert evaluator._select_gold("dacomp-de-arch-001", "/results/en") == (zh, True)
+
+
+@pytest.mark.parametrize(
+    "rubric",
+    [
+        "",
+        "Criterion without a total score.",
+        "## [Total Score | 1 Point]\nCriterion is trunc",
+    ],
+)
+def test_missing_or_truncated_rubric_is_rejected(rubric):
+    evaluator = make_evaluator()
+    assert not evaluator._rubric_is_complete(rubric)
+
+
+def test_empty_blueprint_scores_zero_without_calling_judge(tmp_path):
+    task_name = "dacomp-de-arch-001"
+    (tmp_path / f"{task_name}.yaml").write_text(" \n", encoding="utf-8")
+    gold = {
+        "question": "Question",
+        "rubric": "## [Total Score | 7 Points]\nComplete criterion.",
+    }
+    evaluator = make_evaluator({task_name: gold})
+    evaluator.call_llm_api = lambda *_args, **_kwargs: pytest.fail(
+        "judge must not be called for an empty blueprint"
+    )
+
+    result = evaluator.evaluate_single_task(str(tmp_path), task_name)
+
+    assert result["actual_score"] == 0
+    assert result["max_score"] == 7
+    assert result["error"] == f"Blueprint is empty for task {task_name}"
+
+
+def test_failed_tasks_remain_in_summary_denominator():
+    evaluator = make_evaluator()
+    results = [
+        {"task_name": "ok", "actual_score": 4, "max_score": 5},
+        {"task_name": "empty", "actual_score": 0, "max_score": 7, "error": "empty"},
+    ]
+
+    summary = evaluator.create_summary(results)
+
+    assert summary["total_actual_score"] == 4
+    assert summary["total_max_score"] == 12
+    assert summary["overall_score_rate"] == pytest.approx(4 / 12)
+
+
+def test_all_shipped_tasks_resolve_to_complete_rubrics():
+    evaluator = make_evaluator(
+        evaluation.DEDEvaluator._load_gold_jsonl(
+            make_evaluator(), config.DEFAULT_GOLD_EN_JSONL
+        ),
+        evaluation.DEDEvaluator._load_gold_jsonl(
+            make_evaluator(), config.DEFAULT_GOLD_ZH_JSONL
+        ),
+    )
+
+    for task_name in evaluator.gold_en_map:
+        gold, _is_zh = evaluator._select_gold(task_name, "/results/en")
+        assert evaluator._rubric_is_complete(gold["rubric"]), task_name


### PR DESCRIPTION
## Summary

Fix bilingual scoring in the DE-Arch evaluation suite and preserve accurate score denominators when an input cannot be judged.

The shipped English and Chinese gold files use different score labels, and eight English rubrics are truncated (`002`, `006`, `007`, `012`, `016`, `017`, `019`, and `024`). This could make English tasks score zero or be judged against incomplete criteria.

This change:

- parses both `Total Score` / `Points` and `总分` / `分数` fields
- supports suffixed Chinese task names, project-level language hints, and legacy unsuffixed English tasks
- uses the complete paired Chinese gold only when the matching English rubric is incomplete
- rejects a task when no complete rubric is available
- scores empty blueprints as zero without calling the LLM judge
- keeps known rubric maxima in the denominator for failed or empty tasks
- resolves default gold and result paths relative to the evaluation suite instead of the process working directory

## Validation

- `python -m pytest tests -q` — full suite, 15 passed
- Python compilation check
- `git diff --check`

The tests cover bilingual score extraction, language selection, truncated-rubric fallback, missing-rubric rejection, empty blueprints, denominator preservation, and all 30 shipped DE-Arch task pairs.

## AI assistance

This change was developed with AI assistance. I reviewed the shipped gold data, verified the incomplete rubric set, and ran the checks above.
